### PR TITLE
Fix a typo in transforms.py

### DIFF
--- a/transforms.py
+++ b/transforms.py
@@ -132,7 +132,7 @@ class GroupOverSample(object):
 class GroupMultiScaleCrop(object):
 
     def __init__(self, input_size, scales=None, max_distort=1, fix_crop=True, more_fix_crop=True):
-        self.scales = scales if scales is not None else [1, 875, .75, .66]
+        self.scales = scales if scales is not None else [1, .875, .75, .66]
         self.max_distort = max_distort
         self.fix_crop = fix_crop
         self.more_fix_crop = more_fix_crop


### PR DESCRIPTION
In GroupMultiScaleCrop, the scales should be [1, .875, .75, .66] instead of [1, 875, .75, .66] (Notice the term 875)